### PR TITLE
Update tmvec-search

### DIFF
--- a/scripts/tmvec-search
+++ b/scripts/tmvec-search
@@ -35,7 +35,7 @@ parser.add_argument("--database",
 
 parser.add_argument("--database-fasta",
         type=Path,
-        required=True,
+        required=False,
         help=("Database that contains the corresponding "
               "protein sequences in fasta format.")
 )


### PR DESCRIPTION
We only need to specify a fasta database when using deepblast for alignments.

BTW, it maybe worthwhile having a separate encode command -- right now everything has to be stored in memory (which may cap out on larger queries)