### PR TITLE
Use the `conda-forge` channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ TM-Vec: template modeling vectors for fast homology detection and alignment: htt
 
 First create a conda environment with python=3.9 installed.  If you are using cpu, use
 
-`conda create -n tmvec faiss-cpu python=3.9 -c pytorch`
+`conda create -n tmvec faiss-cpu python=3.9 -c conda-forge`
 
 If the installation fails, you may need to install mkl via `conda install mkl=2021 mkl_fft `
 
 If you are using gpu use
 
-`conda create -n tmvec faiss-gpu python=3.9 -c pytorch`
+`conda create -n tmvec faiss-gpu python=3.9 -c conda-forge`
 
 Once your conda enviroment is installed and activated (i.e. `conda activate tmvec`), then install tm-vec via
 `pip install tm-vec`. If you are using a GPU, you may need to reinstall the gpu version of pytorch.


### PR DESCRIPTION
This PR just changes the installation command to use the conda-forge channel instead of pytorch. When users have no default channels, installation will fail because the pytorch channel doen't provide some required packages, like Python itself.